### PR TITLE
Removed an unnecessary comment from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
-
 version: '3'
 services:
   sec:


### PR DESCRIPTION
## Problem
The comment at the top of the `docker-compose.yml` references an environment variable that was removed by https://github.com/CDOT-CV/jpo-ode/pull/53 and is not necessary.

## Solution
This comment has been removed.

## Testing
Spinning up the project using docker-compose has been verified to work with these changes.