### PR TITLE
Fix: JSON Parsing for response from external signing service

### DIFF
--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -214,7 +214,7 @@ public class SignatureController implements EnvironmentAware {
             try {
                 return new JSONObject(result);
             } catch (JSONException e) {
-                logger.error("Invalid JSON response: [{}]", result, e);
+                logger.error("Invalid JSON response", e);
                 throw new SignatureControllerException("External service returned invalid JSON", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -20,6 +20,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -196,7 +197,11 @@ public class SignatureController implements EnvironmentAware {
                 throw new SignatureControllerException("Unable to read response from external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
-            logger.debug("Returned signature object: {}", result);
+            logger.debug("Raw response from the external service: >>>{}<<<", result);
+            if (result == null || result.trim().isEmpty()) {
+                logger.error("Empty or null response received from the external signing service.");
+                throw new SignatureControllerException("External service returned empty or null response", HttpStatus.BAD_GATEWAY);
+            }
 
             try {
                 EntityUtils.consume(responseEntity);
@@ -205,7 +210,14 @@ public class SignatureController implements EnvironmentAware {
                 throw new SignatureControllerException("Unable to consume response from external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
-            return new JSONObject(result);
+            result = result.trim();
+            try {
+                return new JSONObject(result);
+            } catch (JSONException e) {
+                logger.error("Invalid JSON response: [{}]", result, e);
+                throw new SignatureControllerException("External service returned invalid JSON", HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+
         } else {
             ResponseEntity<String> respEntity = template.postForEntity(uri, entity, String.class);
             logger.debug("Received response: {}", respEntity);


### PR DESCRIPTION
## Description

This change is to fix JSON conversion errors. It also adds some improved exception handling and logging so future maintainers can track down the source of exceptions more easily.

The security service was throwing the following exception:

```text
Addresses the exception encountered:
org.json.JSONException: A JSONObject text must begin with '{' at 1 [character 2 line 1] at org.json.JSONTokener.syntaxError(JSONTokener.java:503) at org.json.JSONObject.<init>(JSONObject.java:208) at org.json.JSONObject.<init>(JSONObject.java:402) at us.dot.its.jpo.sec.controllers.SignatureController.forwardMessageToExternalService(SignatureController.java:208) at us.dot.its.jpo.sec.controllers.SignatureController.sign(SignatureController.java:112)
```

The ODE logs would look like the following when calling the security service and encountering the exception:
```text
"2025-02-21 20:16:41 [Asn1EncodedDataRouter-0-C-1] [,] ERROR SecurityServicesClient - Error sending data to security services module: 500 : "{"timestamp":"2025-02-21T20:16:41.228+00:00","status":500,"error":"Internal Server Error","path":"/sign"}" "
```

## Testing

This code is currently running in GCP dev, and no exceptions are occurring in the security service and ode logs.