### PR TITLE
Update jpo-security-svcs project version to 1.6.0

### DIFF
--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>usdot.jpo.ode</groupId>
 	<artifactId>jpo-security-svcs</artifactId>
-	<version>1.5.0-SNAPSHOT</version>
+	<version>1.6.0</version>
 
 	<packaging>jar</packaging>
 	<name>jpo-security-svcs</name>


### PR DESCRIPTION
## Changes
Updated the version in jpo-security-svcs pom.xml from 1.5.0-SNAPSHOT to 1.6.0 to reflect the latest release.

## Testing
Verified successful compilation & startup using `docker compose up --build`