### PR TITLE
Add release notes for 2025 Q3 release

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,7 +1,7 @@
 Jpo-security-svcs Release Notes
 ----------------------------
 
-Version 1.7.0, released October 2025
+Version 1.6.1, released October 2025
 ----------------------------------------
 ### **Summary**
 The changes for the jpo-security-svcs v1.6.0 release include adding a workflow for external issues notification and migrating to reusable Docker workflows. No changes were made to the functionality of the service.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,16 @@
 Jpo-security-svcs Release Notes
 ----------------------------
 
+Version 1.7.0, released October 2025
+----------------------------------------
+### **Summary**
+The changes for the jpo-security-svcs v1.6.0 release include adding a workflow for external issues notification and migrating to reusable Docker workflows. No changes were made to the functionality of the service.
+
+Enhancements in this release:
+- [USDOT PR 46](https://github.com/usdot-jpo-ode/jpo-security-svcs/pull/46): Add Workflow for External Issues Notification
+- [USDOT PR 47](https://github.com/usdot-jpo-ode/jpo-security-svcs/pull/47): Migrate to Reusable Docker Workflows
+
+
 Version 1.6.0, released May 2025
 ----------------------------------------
 ### **Summary**

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>usdot.jpo.ode</groupId>
 	<artifactId>jpo-security-svcs</artifactId>
-	<version>1.7.0</version>
+	<version>1.6.1</version>
 
 	<packaging>jar</packaging>
 	<name>jpo-security-svcs</name>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>usdot.jpo.ode</groupId>
 	<artifactId>jpo-security-svcs</artifactId>
-	<version>1.6.0</version>
+	<version>1.7.0</version>
 
 	<packaging>jar</packaging>
 	<name>jpo-security-svcs</name>


### PR DESCRIPTION
This PR adds release notes summarizing the recent updates to the jpo-security-svcs project from the past quarter and bumps the version to 1.7.0. While no changes from CDOT are present, there were some modifications to some workflows in the upstream USDOT repository.