### PR TITLE
Upgrade to Spring Boot 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   jpo-security-svcs:
    runs-on: ubuntu-latest
    container:
-     image: openjdk:21-jdk-slim-buster
+     image: eclipse-temurin:21.0.10_7-jdk-ubi9-minimal
      options: --user root
    steps:
      - name: Checkout ${{ github.event.repository.name }}

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -98,13 +98,6 @@
                   <buildDirectory>${project.build.directory}</buildDirectory>
                </systemPropertyVariables>
             </configuration>
-            <dependencies>
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
-				  <version>3.2.5</version>
-                </dependency>
-            </dependencies>
          </plugin>
         <plugin>
             <groupId>org.jacoco</groupId>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -19,8 +19,6 @@
 	<properties>
 		<httpclient5.version>5.4.4</httpclient5.version>
 		    <java.version>21</java.version>
-		    <jmockit.version>1.49</jmockit.version>
-		    <argLine>-javaagent:${user.home}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
 		    <sonar.organization>usdot-jpo-ode-1</sonar.organization>
             <sonar.host.url>https://sonarcloud.io</sonar.host.url>
             <!-- JaCoCo Properties -->
@@ -45,12 +43,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jmockit</groupId>
-			<artifactId>jmockit</artifactId>
-			<version>${jmockit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -98,8 +90,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.0.0-M7</version>
             <configuration>
-               <argLine>
-                  -javaagent:${user.home}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
                <!-- <testFailureIgnore>true</testFailureIgnore> -->
                <enableProcessChecker>all</enableProcessChecker>
                <shutdown>exit</shutdown>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>4.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -17,13 +17,14 @@
 	<name>jpo-security-svcs</name>
 	<description>JPO ODE Cryptography Module</description>
 	<properties>
+		<httpclient5.version>5.4.4</httpclient5.version>
 		    <java.version>21</java.version>
 		    <jmockit.version>1.49</jmockit.version>
 		    <argLine>-javaagent:${user.home}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
 		    <sonar.organization>usdot-jpo-ode-1</sonar.organization>
             <sonar.host.url>https://sonarcloud.io</sonar.host.url>
             <!-- JaCoCo Properties -->
-            <jacoco.version>0.8.11</jacoco.version>
+            <jacoco.version>0.8.14</jacoco.version>
             <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
             <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
             <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -35,7 +36,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,12 +54,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20231013</version>
@@ -69,18 +64,20 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.13</artifactId>
-			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectreactor</groupId>
@@ -118,7 +115,7 @@
                   <version>3.1.2</version>
                 </dependency>
             </dependencies>
-         </plugin>			
+         </plugin>
         <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -35,6 +35,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-jackson</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jackson2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,10 +72,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>usdot.jpo.ode</groupId>
 	<artifactId>jpo-security-svcs</artifactId>
-	<version>1.7.0</version>
+	<version>2.0.0</version>
 
 	<packaging>jar</packaging>
 	<name>jpo-security-svcs</name>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -60,12 +60,12 @@
 			<artifactId>httpclient5</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_2.13</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/jpo-security-svcs/pom.xml
+++ b/jpo-security-svcs/pom.xml
@@ -88,7 +88,7 @@
 		 <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M7</version>
+			<version>3.5.2</version>
             <configuration>
                <!-- <testFailureIgnore>true</testFailureIgnore> -->
                <enableProcessChecker>all</enableProcessChecker>
@@ -102,7 +102,7 @@
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
                   <artifactId>surefire-junit4</artifactId>
-                  <version>3.1.2</version>
+				  <version>3.2.5</version>
                 </dependency>
             </dependencies>
          </plugin>

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -16,10 +16,12 @@
 package us.dot.its.jpo.sec.controllers;
 
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.HttpEntityContainer;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -174,12 +176,8 @@ public class SignatureController implements EnvironmentAware {
 
             HttpPost httpPost = new HttpPost(uri);
             httpPost.setHeader("Content-Type", "application/json");
-            org.apache.http.HttpEntity postEntity;
-            try {
-                postEntity = new org.apache.http.entity.StringEntity(new JSONObject(map).toString());
-            } catch (UnsupportedEncodingException e) {
-                throw new SignatureControllerException("Invalid request body.", HttpStatus.BAD_REQUEST);
-            }
+            org.apache.hc.core5.http.HttpEntity postEntity;
+            postEntity = new org.apache.hc.core5.http.io.entity.StringEntity(new JSONObject(map).toString());
             httpPost.setEntity(postEntity);
 
             HttpResponse response;
@@ -190,11 +188,12 @@ public class SignatureController implements EnvironmentAware {
                 throw new SignatureControllerException("Unable to sign message.", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
-            org.apache.http.HttpEntity responseEntity = response.getEntity();
+            org.apache.hc.core5.http.HttpEntity responseEntity =
+                    ((HttpEntityContainer) response).getEntity();
             String result;
             try {
                 result = httpEntityStringifier.stringifyHttpEntity(responseEntity);
-            } catch (IOException e) {
+            } catch (IOException | ParseException e) {
                 logger.error("Unable to read response from external signing service: {}", e.getMessage(), e);
                 throw new SignatureControllerException("Unable to read response from external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -16,12 +16,8 @@
 package us.dot.its.jpo.sec.controllers;
 
 
-import org.apache.hc.core5.http.HttpEntityContainer;
-import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -169,46 +165,28 @@ public class SignatureController implements EnvironmentAware {
                 throw new SignatureControllerException("Unable to connect to external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
-            HttpClient httpClient = httpClientFactory.getHttpClient(sslContext);
+            CloseableHttpClient httpClient = httpClientFactory.getHttpClient(sslContext);
             if (httpClient == null) {
                 throw new SignatureControllerException("Unable to connect to external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             HttpPost httpPost = new HttpPost(uri);
             httpPost.setHeader("Content-Type", "application/json");
-            org.apache.hc.core5.http.HttpEntity postEntity;
-            postEntity = new org.apache.hc.core5.http.io.entity.StringEntity(new JSONObject(map).toString());
-            httpPost.setEntity(postEntity);
+            httpPost.setEntity(new org.apache.hc.core5.http.io.entity.StringEntity(new JSONObject(map).toString()));
 
-            HttpResponse response;
-            try {
-                response = httpClient.execute(httpPost);
-            } catch (IOException e) {
-                logger.error("Unable to execute http request: {}", e.getMessage(), e);
-                throw new SignatureControllerException("Unable to sign message.", HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-
-            org.apache.hc.core5.http.HttpEntity responseEntity =
-                    ((HttpEntityContainer) response).getEntity();
             String result;
             try {
-                result = httpEntityStringifier.stringifyHttpEntity(responseEntity);
-            } catch (IOException | ParseException e) {
-                logger.error("Unable to read response from external signing service: {}", e.getMessage(), e);
-                throw new SignatureControllerException("Unable to read response from external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
+                result = httpClient.execute(httpPost, response ->
+                        httpEntityStringifier.stringifyHttpEntity(response.getEntity()));
+            } catch (IOException e) {
+                logger.error("Unable to execute request or read response from external signing service: {}", e.getMessage(), e);
+                throw new SignatureControllerException("Unable to sign message.", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             logger.debug("Raw response from the external service: >>>{}<<<", result);
             if (result == null || result.trim().isEmpty()) {
                 logger.error("Empty or null response received from the external signing service.");
                 throw new SignatureControllerException("External service returned empty or null response", HttpStatus.BAD_GATEWAY);
-            }
-
-            try {
-                EntityUtils.consume(responseEntity);
-            } catch (IOException e) {
-                logger.error("Unable to consume response from external signing service: {}", e.getMessage(), e);
-                throw new SignatureControllerException("Unable to consume response from external signing service", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             result = result.trim();

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
@@ -2,7 +2,7 @@ package us.dot.its.jpo.sec.helpers;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HttpClientFactory {
         
-        public HttpClient getHttpClient(SSLContext sslContext) {
+        public CloseableHttpClient getHttpClient(SSLContext sslContext) {
             HttpClientBuilder httpClientBuilder = HttpClients.custom();
             if (sslContext == null) {
                 return null;

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
@@ -5,6 +5,10 @@ import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,7 +19,12 @@ public class HttpClientFactory {
             if (sslContext == null) {
                 return null;
             }
-            httpClientBuilder.setSSLContext(sslContext);
-            return httpClientBuilder.build();
+            TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(sslContext);
+
+            HttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                    .setTlsSocketStrategy(tlsStrategy)
+                    .build();
+
+            return httpClientBuilder.setConnectionManager(connectionManager).build();
         }
 }

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpClientFactory.java
@@ -2,9 +2,9 @@ package us.dot.its.jpo.sec.helpers;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifier.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifier.java
@@ -2,14 +2,14 @@ package us.dot.its.jpo.sec.helpers;
 
 import java.io.IOException;
 
-import org.apache.http.ParseException;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.ParseException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class HttpEntityStringifier {
     
-    public String stringifyHttpEntity(org.apache.http.HttpEntity apache_entity) throws ParseException, IOException {
+    public String stringifyHttpEntity(org.apache.hc.core5.http.HttpEntity apache_entity) throws ParseException, IOException {
         return EntityUtils.toString(apache_entity);
     }
 }

--- a/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/SSLContextFactory.java
+++ b/jpo-security-svcs/src/main/java/us/dot/its/jpo/sec/helpers/SSLContextFactory.java
@@ -9,7 +9,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 
 import javax.net.ssl.SSLContext;
-import org.apache.http.ssl.SSLContexts;
+import org.apache.hc.core5.ssl.SSLContexts;
 
 @Component
 public class SSLContextFactory {

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/ApplicationTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/ApplicationTest.java
@@ -1,25 +1,19 @@
 package us.dot.its.jpo.sec;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.boot.SpringApplication;
 
-import mockit.Capturing;
-import mockit.Expectations;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 
 public class ApplicationTest {
 
-   @Capturing
-   SpringApplication capturingSpringApplication;
-
    @Test
    public void test() {
-      new Expectations() {
-         {
-            SpringApplication.run((Class<?>) any, (String[]) any);
-            times = 1;
-         }
-      };
-      Application.main(new String[] { "testArg" });
+      try (MockedStatic<SpringApplication> mocked = mockStatic(SpringApplication.class)) {
+         Application.main(new String[] { "testArg" });
+         mocked.verify(() -> SpringApplication.run(any(Class.class), any(String[].class)));
+      }
    }
-
 }

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/ApplicationTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/ApplicationTest.java
@@ -1,6 +1,6 @@
 package us.dot.its.jpo.sec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 
 import mockit.Capturing;

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
@@ -1,7 +1,7 @@
 package us.dot.its.jpo.sec.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import mockit.Injectable;
+import org.mockito.Mock;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ParseException;
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
@@ -54,7 +53,7 @@ class SignatureControllerTest {
     @Mock
     HttpEntityStringifier mockHttpEntityStringifier;
 
-    @Injectable
+    @Mock
     Environment environment;
 
     @InjectMocks
@@ -162,7 +161,7 @@ class SignatureControllerTest {
     }
 
     @Test
-    void testForwardMessageToExternalService_useCertificates_True_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, JSONException, SignatureControllerException {
+    void testForwardMessageToExternalService_useCertificates_True_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, JSONException, SignatureControllerException, ParseException {
         // prepare
         setUp();
         uut.setUseCertificates(true);

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
@@ -1,16 +1,18 @@
 package us.dot.its.jpo.sec.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.mockito.Mock;
-import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,7 @@ import java.security.UnrecoverableKeyException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -72,7 +75,7 @@ class SignatureControllerTest {
     }
 
     @Test
-    void testSign_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, SignatureControllerException, ParseException {
+    void testSign_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, SignatureControllerException, ParseException, ParseException {
         // prepare
         setUp();
         uut.setUseCertificates(true);
@@ -80,13 +83,16 @@ class SignatureControllerTest {
         uut.setCryptoServiceEndpointSignPath("endpoint");
         SSLContext mockSSLContext = mock(SSLContext.class);
         doReturn(mockSSLContext).when(mockSSLContextFactory).getSSLContext(any(), any());
-        HttpClient mockHttpClient = mock(HttpClient.class);
+        CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
         doReturn(mockHttpClient).when(mockHttpClientFactory).getHttpClient(mockSSLContext);
         ClassicHttpResponse mockHttpResponse = mock(ClassicHttpResponse.class);
-        doReturn(mockHttpResponse).when(mockHttpClient).execute(any());
         org.apache.hc.core5.http.HttpEntity mockHttpEntity = mock(org.apache.hc.core5.http.HttpEntity.class);
         doReturn(mockHttpEntity).when(mockHttpResponse).getEntity();
         doReturn("{\"message-signed\":\"test12345\",\"message-expiry\":1}").when(mockHttpEntityStringifier).stringifyHttpEntity(mockHttpEntity);
+        doAnswer(invocation -> {
+            HttpClientResponseHandler<String> responseHandler = invocation.getArgument(1);
+            return responseHandler.handleResponse(mockHttpResponse);
+        }).when(mockHttpClient).execute(any(HttpPost.class), any(HttpClientResponseHandler.class));
         Message message = new Message();
         message.setMsg("test");
 
@@ -110,7 +116,7 @@ class SignatureControllerTest {
         message.setMsg("test");
 
         // execute
-        assertThrows(SignatureControllerException.class , () -> uut.sign(message));
+        assertThrows(SignatureControllerException.class, () -> uut.sign(message));
     }
 
     @Test
@@ -122,7 +128,8 @@ class SignatureControllerTest {
         Message message = new Message();
         message.setMsg("test");
 
-        assertThrows(SignatureControllerException.class , () -> uut.sign(message));
+        // execute
+        assertThrows(SignatureControllerException.class, () -> uut.sign(message));
     }
 
     @Test
@@ -169,13 +176,16 @@ class SignatureControllerTest {
         uut.setCryptoServiceEndpointSignPath("endpoint");
         SSLContext mockSSLContext = mock(SSLContext.class);
         doReturn(mockSSLContext).when(mockSSLContextFactory).getSSLContext(any(), any());
-        HttpClient mockHttpClient = mock(HttpClient.class);
+        CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
         doReturn(mockHttpClient).when(mockHttpClientFactory).getHttpClient(mockSSLContext);
         ClassicHttpResponse mockHttpResponse = mock(ClassicHttpResponse.class);
-        doReturn(mockHttpResponse).when(mockHttpClient).execute(any());
         org.apache.hc.core5.http.HttpEntity mockHttpEntity = mock(org.apache.hc.core5.http.HttpEntity.class);
         doReturn(mockHttpEntity).when(mockHttpResponse).getEntity();
         doReturn("{\"result\":\"test\"}").when(mockHttpEntityStringifier).stringifyHttpEntity(mockHttpEntity);
+        doAnswer(invocation -> {
+            HttpClientResponseHandler<String> responseHandler = invocation.getArgument(1);
+            return responseHandler.handleResponse(mockHttpResponse);
+        }).when(mockHttpClient).execute(any(HttpPost.class), any(HttpClientResponseHandler.class));
         Message message = new Message();
         message.setMsg("test");
 
@@ -198,7 +208,7 @@ class SignatureControllerTest {
         message.setMsg("test");
 
         // execute
-        assertThrows(SignatureControllerException.class,  () -> uut.forwardMessageToExternalService(message));
+        assertThrows(SignatureControllerException.class, () -> uut.forwardMessageToExternalService(message));
     }
 
     @Test
@@ -215,7 +225,7 @@ class SignatureControllerTest {
         message.setMsg("test");
 
         // execute
-        assertThrows(SignatureControllerException.class,  () -> uut.forwardMessageToExternalService(message));
+        assertThrows(SignatureControllerException.class, () -> uut.forwardMessageToExternalService(message));
     }
 
     @Test

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/controllers/SignatureControllerTest.java
@@ -2,8 +2,9 @@ package us.dot.its.jpo.sec.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import mockit.Injectable;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ParseException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +73,7 @@ class SignatureControllerTest {
     }
 
     @Test
-    void testSign_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, SignatureControllerException {
+    void testSign_SUCCESS() throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, IOException, SignatureControllerException, ParseException {
         // prepare
         setUp();
         uut.setUseCertificates(true);
@@ -82,9 +83,9 @@ class SignatureControllerTest {
         doReturn(mockSSLContext).when(mockSSLContextFactory).getSSLContext(any(), any());
         HttpClient mockHttpClient = mock(HttpClient.class);
         doReturn(mockHttpClient).when(mockHttpClientFactory).getHttpClient(mockSSLContext);
-        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        ClassicHttpResponse mockHttpResponse = mock(ClassicHttpResponse.class);
         doReturn(mockHttpResponse).when(mockHttpClient).execute(any());
-        org.apache.http.HttpEntity mockHttpEntity = mock(org.apache.http.HttpEntity.class);
+        org.apache.hc.core5.http.HttpEntity mockHttpEntity = mock(org.apache.hc.core5.http.HttpEntity.class);
         doReturn(mockHttpEntity).when(mockHttpResponse).getEntity();
         doReturn("{\"message-signed\":\"test12345\",\"message-expiry\":1}").when(mockHttpEntityStringifier).stringifyHttpEntity(mockHttpEntity);
         Message message = new Message();
@@ -171,9 +172,9 @@ class SignatureControllerTest {
         doReturn(mockSSLContext).when(mockSSLContextFactory).getSSLContext(any(), any());
         HttpClient mockHttpClient = mock(HttpClient.class);
         doReturn(mockHttpClient).when(mockHttpClientFactory).getHttpClient(mockSSLContext);
-        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        ClassicHttpResponse mockHttpResponse = mock(ClassicHttpResponse.class);
         doReturn(mockHttpResponse).when(mockHttpClient).execute(any());
-        org.apache.http.HttpEntity mockHttpEntity = mock(org.apache.http.HttpEntity.class);
+        org.apache.hc.core5.http.HttpEntity mockHttpEntity = mock(org.apache.hc.core5.http.HttpEntity.class);
         doReturn(mockHttpEntity).when(mockHttpResponse).getEntity();
         doReturn("{\"result\":\"test\"}").when(mockHttpEntityStringifier).stringifyHttpEntity(mockHttpEntity);
         Message message = new Message();

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpClientFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpClientFactoryTest.java
@@ -4,13 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.apache.hc.client5.http.classic.HttpClient;
-
-import mockit.Tested;
+import org.mockito.InjectMocks;
 
 @ExtendWith(MockitoExtension.class)
 public class HttpClientFactoryTest {
 
-    @Tested
+    @InjectMocks
     HttpClientFactory httpClientFactory = new HttpClientFactory();
     
     @Test

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpClientFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpClientFactoryTest.java
@@ -1,9 +1,9 @@
 package us.dot.its.jpo.sec.helpers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.apache.http.client.HttpClient;
+import org.apache.hc.client5.http.classic.HttpClient;
 
 import mockit.Tested;
 

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifierTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifierTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import mockit.Tested;
+import org.mockito.InjectMocks;
 
 @ExtendWith(MockitoExtension.class)
 public class HttpEntityStringifierTest {
     
-    @Tested
+    @InjectMocks
     HttpEntityStringifier httpEntityStringifier = new HttpEntityStringifier();
 
     @Test

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifierTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/HttpEntityStringifierTest.java
@@ -2,8 +2,8 @@ package us.dot.its.jpo.sec.helpers;
 
 import java.io.IOException;
 
-import org.apache.http.ParseException;
-import org.junit.Test;
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -18,7 +18,7 @@ public class HttpEntityStringifierTest {
     @Test
     public void testStringifyHttpEntity() throws ParseException, IOException {
         // prepare
-        org.apache.http.HttpEntity apache_entity = new org.apache.http.entity.StringEntity("test");
+        org.apache.hc.core5.http.HttpEntity apache_entity = new org.apache.hc.core5.http.io.entity.StringEntity("test");
         
         // execute
         String stringified = httpEntityStringifier.stringifyHttpEntity(apache_entity);

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/KeyStoreReaderTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/KeyStoreReaderTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import mockit.Tested;
+import org.mockito.InjectMocks;
 
 @ExtendWith(MockitoExtension.class)
 public class KeyStoreReaderTest {
 
-    @Tested
+    @InjectMocks
     KeyStoreReader keyStoreReader = new KeyStoreReader();
 
     private void createKeyStoreForTesting() throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/KeyStoreReaderTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/KeyStoreReaderTest.java
@@ -1,6 +1,6 @@
 package us.dot.its.jpo.sec.helpers;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -10,7 +10,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/RestTemplateFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/RestTemplateFactoryTest.java
@@ -1,6 +1,6 @@
 package us.dot.its.jpo.sec.helpers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/RestTemplateFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/RestTemplateFactoryTest.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
 
-import mockit.Tested;
+import org.mockito.InjectMocks;
 
 @ExtendWith(MockitoExtension.class)
 public class RestTemplateFactoryTest {
 
-    @Tested
+    @InjectMocks
     RestTemplateFactory restTemplateFactory = new RestTemplateFactory();
     
     @Test

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/SSLContextFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/SSLContextFactoryTest.java
@@ -1,7 +1,5 @@
 package us.dot.its.jpo.sec.helpers;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -17,12 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import mockit.Tested;
+import org.mockito.InjectMocks;
 
 @ExtendWith(MockitoExtension.class)
 public class SSLContextFactoryTest {
     
-    @Tested
+    @InjectMocks
     SSLContextFactory sslContextFactory = new SSLContextFactory();
 
     @Test

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/SSLContextFactoryTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/helpers/SSLContextFactoryTest.java
@@ -12,8 +12,8 @@ import java.security.cert.CertificateException;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.ParseException;
-import org.junit.Test;
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 

--- a/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/models/MessageTest.java
+++ b/jpo-security-svcs/src/test/java/us/dot/its/jpo/sec/models/MessageTest.java
@@ -1,6 +1,6 @@
 package us.dot.its.jpo.sec.models;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MessageTest {
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.jacksonized.jacksonVersion += 3

--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,0 @@
-lombok.jacksonized.jacksonVersion += 3

--- a/mock-signing-svc/HELP.md
+++ b/mock-signing-svc/HELP.md
@@ -4,11 +4,11 @@
 For further reference, please consider the following sections:
 
 * [Official Apache Maven documentation](https://maven.apache.org/guides/index.html)
-* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/3.4.1/maven-plugin)
-* [Create an OCI image](https://docs.spring.io/spring-boot/3.4.1/maven-plugin/build-image.html)
-* [Spring Web](https://docs.spring.io/spring-boot/3.4.1/reference/web/servlet.html)
-* [Spring Boot DevTools](https://docs.spring.io/spring-boot/3.4.1/reference/using/devtools.html)
-* [Spring Configuration Processor](https://docs.spring.io/spring-boot/3.4.1/specification/configuration-metadata/annotation-processor.html)
+* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/4.0.6/maven-plugin/)
+* [Create an OCI image](https://docs.spring.io/spring-boot/4.0.6/maven-plugin/build-image.html)
+* [Spring Web](https://docs.spring.io/spring-boot/4.0.6/reference/web/servlet.html)
+* [Spring Boot DevTools](https://docs.spring.io/spring-boot/4.0.6/reference/using/devtools.html)
+* [Spring Configuration Processor](https://docs.spring.io/spring-boot/4.0.6/specification/configuration-metadata/annotation-processor.html)
 
 ### Guides
 The following guides illustrate how to use some features concretely:

--- a/mock-signing-svc/pom.xml
+++ b/mock-signing-svc/pom.xml
@@ -20,6 +20,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-jackson</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jackson2</artifactId>
 		</dependency>
 
 		<dependency>

--- a/mock-signing-svc/pom.xml
+++ b/mock-signing-svc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.1</version>
+		<version>4.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>us.dot.its.jpo.sec.mock</groupId>
@@ -19,7 +19,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
# PR Details

## Description

This PR migrates the repository to Spring Boot 4.0.x and removes the incompatible JMockit testing library in favor of the actively maintained Mockito and JUnit 5 framework bundled with Spring Boot Test. Deprecated APIs were switched out to the updated and recommended APIs with similar functionality.

**Apache HttpClient 4 → 5**

Migrates from `org.apache.http` to `org.apache.hc.core5` to align with Spring Boot 4's updated dependencies.

`HttpClientFactory` now returns `CloseableHttpClient` and configures SSL through the HttpClient 5 recommended path: `DefaultClientTlsStrategy` + `PoolingHttpClientConnectionManagerBuilder`, replacing the deprecated `HttpClientBuilder.setSSLContext()`.

In the controller, `StringEntity` no longer throws `UnsupportedEncodingException`, removing a now-unnecessary try/catch. The manual execute → read → `EntityUtils.consume()` pattern (deprecated in HttpClient 5) is replaced with the response callback pattern (`httpClient.execute(request, response -> ...)`), which automatically handles entity consumption and connection release. The 3 separate try/catch blocks collapse into 1, and the previous risk of connection pool leaks if an exception was thrown before `EntityUtils.consume()` is eliminated.

## How was this tested

1. I ran the unit tests with `mvn clean verify` and they all passed.
3. I compiled and ran mock-signing-svc and jpo-security-svcs locally and used the testing script hit_endpoint.sh to verify results. Here is the result on one such run: {"messageExpiry":"null","messageSigned":"test112e4910"}
4. I built and ran the jpo-security-svcs with mock-signing-svc together and separately using docker-compose.
