### PR TITLE
Adding USDOT owner restriction to dockerhub.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,11 @@ jobs:
   jpo-security-svcs:
    runs-on: ubuntu-latest
    container:
-    image: 'openjdk:21-jdk-slim-bookworm'
+    image: maven:3.9.9-eclipse-temurin-21
     options: --user root
    steps:
      - name: Checkout ${{ github.event.repository.name }}
-       uses: actions/checkout@v4    
-     - name: Set up Maven
-       uses: stCarolas/setup-maven@v4.5
-       with:
-        maven-version: 3.8.2              
+       uses: actions/checkout@v4
      - name: Build 
        run: |
          cd $GITHUB_WORKSPACE/jpo-security-svcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   jpo-security-svcs:
    runs-on: ubuntu-latest
    container:
-     image: openjdk:21-jdk-slim-buster
-     options: --user root
+    image: 'openjdk:21-jdk-slim-bookworm'
+    options: --user root
    steps:
      - name: Checkout ${{ github.event.repository.name }}
        uses: actions/checkout@v4    

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository_owner == 'usdot-jpo-ode'
     uses: usdot-jpo-ode/actions/.github/workflows/dockerhub.yml@main
     with:
       image: usdotjpoode/jpo-security-svcs


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This change prevents unwanted pushes to dockerhub on this forked repository by restricting dockerhub pushes to only repos in the `usdot-jpo-ode` owner organization. 
This also features a bugfix in which the CI pipeline docker image `openjdk:21-jdk-slim-buster` to `maven:3.9.9-eclipse-temurin-21` (as debian 10/buster reached [EOL](https://www.debian.org/News/2024/20240615) in 2024, and the dockerhub most of the openjdk images were removed that are not early-access).

## Related GitHub Issue

DevOps: [Security Services DockerHub Fail](https://dev.azure.com/SOC-OIT/CDOT/_sprints/taskboard/CDOT%20Connected%20Vehicles/CDOT/CDOT%20Connected%20Vehicles/CV%20Sprint%2095?workitem=489740)

## Motivation and Context

The dockerhub publish pipeline was attempting (and failing) to push images from this repository, which is a fork of the original. 

## How Has This Been Tested?

This change has not been tested, but will be verified once this branch is merged to master. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.